### PR TITLE
Give default empty molecularProfileIds instead of using undefined

### DIFF
--- a/src/shared/lib/isSampleProfiled.ts
+++ b/src/shared/lib/isSampleProfiled.ts
@@ -62,7 +62,7 @@ export function isSampleProfiledInSomeMolecularProfile(
 
 export function isSampleProfiledInMultiple(
     uniqueSampleKey: string,
-    molecularProfileIds: string[],
+    molecularProfileIds: string[] = [],
     coverageInformation: CoverageInformation,
     hugoGeneSymbol?: string
 ): boolean[] {


### PR DESCRIPTION
Fix cBioPortal/cbioportal#9076